### PR TITLE
Compare against torchaudio rnnt

### DIFF
--- a/espnet/nets/pytorch_backend/transducer/loss.py
+++ b/espnet/nets/pytorch_backend/transducer/loss.py
@@ -3,7 +3,6 @@
 """Transducer loss module."""
 
 import torch
-import torchaudio
 
 
 class TransLoss(torch.nn.Module):
@@ -22,6 +21,10 @@ class TransLoss(torch.nn.Module):
 
         if trans_type == "warp-transducer":
             from warprnnt_pytorch import RNNTLoss
+
+            self.trans_loss = RNNTLoss(blank=blank_id)
+        elif trans_type == "torchaudio":
+            from torchaudio.prototype.transducer import RNNTLoss
 
             self.trans_loss = RNNTLoss(blank=blank_id)
         elif trans_type == "warp-rnnt":
@@ -75,11 +78,6 @@ class TransLoss(torch.nn.Module):
             )
         else:
             loss = self.trans_loss(pred_pad, target, pred_len, target_len)
-
-        loss1 = loss.item()
-        loss = torchaudio.prototype.transducer.rnnt_loss(pred_pad, target, pred_len, target_len, blank=self.blank_id, reduction="mean")
-        loss2 = loss.item()
-        print("--> diff", abs(loss1 - loss2), "loss1", loss1, "loss2", loss2)
-
         loss = loss.to(dtype=dtype)
+
         return loss

--- a/espnet/nets/pytorch_backend/transducer/loss.py
+++ b/espnet/nets/pytorch_backend/transducer/loss.py
@@ -3,6 +3,7 @@
 """Transducer loss module."""
 
 import torch
+import torchaudio
 
 
 class TransLoss(torch.nn.Module):
@@ -74,6 +75,11 @@ class TransLoss(torch.nn.Module):
             )
         else:
             loss = self.trans_loss(pred_pad, target, pred_len, target_len)
-        loss = loss.to(dtype=dtype)
 
+        loss1 = loss.item()
+        loss = torchaudio.prototype.transducer.rnnt_loss(pred_pad, target, pred_len, target_len, blank=self.blank_id, reduction="mean")
+        loss2 = loss.item()
+        print("--> diff", abs(loss1 - loss2), "loss1", loss1, "loss2", loss2)
+
+        loss = loss.to(dtype=dtype)
         return loss

--- a/test/test_e2e_asr_transducer.py
+++ b/test/test_e2e_asr_transducer.py
@@ -295,7 +295,7 @@ def test_pytorch_transducer_trainable_and_decodable(train_dic, recog_dic):
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="gpu required")
-@pytest.mark.parametrize("trans_type", ["warp-transducer", "warp-rnnt"])
+@pytest.mark.parametrize("trans_type", ["warp-transducer", "warp-rnnt", "torchaudio"])
 def test_pytorch_transducer_gpu_trainable(trans_type):
     idim, odim, ilens, olens = get_default_scope_inputs()
     train_args = get_default_train_args(trans_type=trans_type)


### PR DESCRIPTION
This PR imports the RNN-T prototype in place of warp-transudcer or warp-rnnt and show that the difference is zero, and all tests are passing.